### PR TITLE
Safe cloning user object for further serialization

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -125,7 +125,7 @@ const ensureValuesAreStrings = (...rest) => {
 };
 
 const sanitizeUserForClient = user => {
-  const user1 = cloneUserObject(user);
+  const user1 = cloneObject(user);
 
   delete user1.password;
   delete user1.verifyExpires;
@@ -140,37 +140,37 @@ const sanitizeUserForClient = user => {
 };
 
 const sanitizeUserForNotifier = user => {
-  const user1 = cloneUserObject(user);
+  const user1 = cloneObject(user);
   delete user1.password;
   return user1;
 };
 
 /**
- * Returns new object with values cloned from original user object.
- * Some objects (like Sequelize model instances) contain circular references
+ * Returns new object with values cloned from the original object. Some objects
+ * (like Sequelize or MongoDB model instances) contain circular references
  * and cause TypeError when trying to JSON.stringify() them. They may contain
- * custom toJSON() method which allows to serialize them safely.
- * Object.assign() does not clone original toJSON(), so the purpose of this method
- * is to use result of custom toJSON() (if accessible) for Object.assign(),
- * but only in case of serialization failure.
+ * custom toJSON() or toObject() method which allows to serialize them safely.
+ * Object.assign() does not clone these methods, so the purpose of this method
+ * is to use result of custom toJSON() or toObject() (if accessible)
+ * for Object.assign(), but only in case of serialization failure.
  *
- * @param {Object?} user - Object to clone
- * @returns {Object} Cloned user object
+ * @param {Object?} obj - Object to clone
+ * @returns {Object} Cloned object
  */
-const cloneUserObject = user => {
-  let user1 = user;
+const cloneObject = obj => {
+  let obj1 = obj;
 
-  if (typeof user.toJSON === 'function') {
+  if (typeof obj.toJSON === 'function' || typeof obj.toObject === 'function') {
     try {
-      JSON.stringify(Object.assign({}, user1));
+      JSON.stringify(Object.assign({}, obj1));
     } catch (e) {
-      debug('User object is not serializable');
+      debug('Object is not serializable');
 
-      user1 = user1.toJSON();
+      obj1 = obj1.toJSON ? obj1.toJSON() : obj1.toObject();
     }
   }
 
-  return Object.assign({}, user1);
+  return Object.assign({}, obj1);
 };
 
 const notifier = (optionsNotifier, type, user, notifierOptions) => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,56 @@
+const assert = require('chai').assert;
+const helpers = require('../src/helpers');
+
+describe('helpers - sanitization', () => {
+  it('allows to stringify sanitized user object', () => {
+    const user = {
+      id: 1,
+      email: 'test@test.test',
+      password: '0000000000',
+      resetToken: 'aaa',
+    };
+
+    const result1 = helpers.sanitizeUserForClient(user);
+    const result2 = helpers.sanitizeUserForNotifier(user);
+
+    assert.doesNotThrow(() => JSON.stringify(result1));
+    assert.doesNotThrow(() => JSON.stringify(result2));
+  });
+
+  it('throws error when stringifying sanitized object with circular reference', () => {
+    const user = {
+      id: 1,
+      email: 'test@test.test',
+      password: '0000000000',
+      resetToken: 'aaa'
+    };
+
+    user.self = user;
+
+    const result1 = helpers.sanitizeUserForClient(user);
+    const result2 = helpers.sanitizeUserForNotifier(user);
+
+    assert.throws(() => JSON.stringify(result1), TypeError);
+    assert.throws(() => JSON.stringify(result2), TypeError);
+  });
+
+  it('allows to stringify sanitized object with circular reference and custom toJSON()', () => {
+    const user = {
+      id: 1,
+      email: 'test@test.test',
+      password: '0000000000',
+      resetToken: 'aaa',
+      toJSON: function() {
+        return Object.assign({}, this, { self: undefined });
+      }
+    };
+
+    user.self = user;
+
+    const result1 = helpers.sanitizeUserForClient(user);
+    const result2 = helpers.sanitizeUserForNotifier(user);
+
+    assert.doesNotThrow(() => JSON.stringify(result1));
+    assert.doesNotThrow(() => JSON.stringify(result2));
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -53,4 +53,24 @@ describe('helpers - sanitization', () => {
     assert.doesNotThrow(() => JSON.stringify(result1));
     assert.doesNotThrow(() => JSON.stringify(result2));
   });
+
+  it('allows to stringify sanitized object with circular reference and custom toObject()', () => {
+    const user = {
+      id: 1,
+      email: 'test@test.test',
+      password: '0000000000',
+      resetToken: 'aaa',
+      toObject: function() {
+        return Object.assign({}, this, { self: undefined });
+      }
+    };
+
+    user.self = user;
+
+    const result1 = helpers.sanitizeUserForClient(user);
+    const result2 = helpers.sanitizeUserForNotifier(user);
+
+    assert.doesNotThrow(() => JSON.stringify(result1));
+    assert.doesNotThrow(() => JSON.stringify(result2));
+  });
 });


### PR DESCRIPTION
Hello,

I tried to use this module with my feathers app and `feathers-sequelize` Users service, but functions `sanitizeUserForClient` and `sanitizeUserForNotifier` cause error:

```
TypeError: Converting circular structure to JSON
    at Object.stringify (native)
    at stringify (/***/node_modules/express/lib/response.js:1064:12)
    at ServerResponse.json (/***/node_modules/express/lib/response.js:243:14)
    at Object.applicationJson [as application/json] (/***/node_modules/feathers-rest/lib/index.js:27:11)
    at ServerResponse.res.format (/***/node_modules/express/lib/response.js:628:13)
    at formatter (/***/node_modules/feathers-rest/lib/index.js:25:7)
    at Layer.handle [as handle_request] (/***/node_modules/express/lib/router/layer.js:95:5)
    at next (/***/node_modules/express/lib/router/route.js:131:13)
    at Object.callback (/***/node_modules/feathers-rest/lib/wrappers.js:87:14)
    at callbackWrapper (/***/node_modules/rubberduck/lib/rubberduck.js:50:20)
    at /***/node_modules/feathers/lib/mixins/promise.js:35:14
```

I think this is because `Object.assign()` does not copy values like custom `toJSON` method, which is used e.g. in Sequelize model objects and is necessary for proper object serialization.

I came up with idea of checking for existence of custom `toJSON` method in user object and then using it's result as a source for new user object. It happens only when `JSON.stringify()` throws error, so in my opinion - only when necessary.

The caveat is that after object sanitization, sequelize methods inside model object will not be accessible, but this is the same situation as current.

Please let me know what do you think.