### PR TITLE
Bumped major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "feathers-authentication-management",
   "description": "Adds sign up verification, forgotten password reset, and other capabilities to local feathers-authentication ",
-  "version": "0.1.7",
+  "version": "1.0.0",
   "homepage": "https://github.com/feathersjs/feathers-authentication-management",
   "main": "lib/",
   "keywords": [


### PR DESCRIPTION
The repo was likley compatible with auth v0.7 and v1 but its best to be
safe and make a clean break wuth auth v0.7. Hence forcing a breaking version change.

@daffl feel free to publish.