### PR TITLE
Resolve `checkUnique` with `null` when no collisions

### DIFF
--- a/src/checkUniqueness.js
+++ b/src/checkUniqueness.js
@@ -37,5 +37,7 @@ module.exports = function checkUniqueness (options, identifyUser, ownId, meta) {
           { errors: errs }
         );
       }
+    
+      return null;
     });
 };


### PR DESCRIPTION
When `checkUnique` does not detect any identityProps collisions, it currently resolves with `undefined`. This seems to cause feathers (specifically feathers-rest) to not respond and just let the express middleware chain carry on. If we resolve with `null`, then feathers-rest responds with a `204 No Content` empty response (which is better than a 404).

See #14 