### PR TITLE
Update docs for addVerification hook

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -378,9 +378,9 @@ store.dispatch(signin.authenticate({ type: 'local', email, password }))
 ## Hooks
 The service does not itself handle creation of a new user account nor the sending of the initial
 sign up verification request.
-Instead hooks are provided for you to use with the `users` service `create` method.
+Instead hooks are provided for you to use with the `users` service `create` method. If you set a service path other than the default of `'authManagement'`, the custom path name must be passed into the hook.
 
-### `verifyHooks.addVerification()`
+### `verifyHooks.addVerification( path = 'authManagement' )`
 
 ```javascript
 const verifyHooks = require('feathers-authentication-management').hooks;


### PR DESCRIPTION
### Summary

I using a custom service path for authentication management and discovered that the custom path name needed to be passed in to the `addVerification` hook. This wasn't listed in the docs, so I added a note.