### PR TITLE
Update all dependencies to version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,23 +60,23 @@
     "bcryptjs": "^2.3.0",
     "crypto": "^0.0.3",
     "debug": "^2.6.4",
-    "feathers-authentication-local": "0.3.4",
-    "feathers-errors": "2.7.0",
-    "feathers-hooks-common": "3.0.0"
+    "feathers-authentication-local": "^0.3.4",
+    "feathers-errors": "^2.7.1",
+    "feathers-hooks-common": "^3.0.0"
   },
   "devDependencies": {
-    "babel-cli": "6.24.1",
-    "babel-core": "6.24.1",
-    "babel-plugin-add-module-exports": "0.2.1",
-    "babel-polyfill": "6.23.0",
-    "babel-preset-es2015": "6.24.1",
-    "chai": "3.5.0",
-    "feathers": "2.1.1",
-    "feathers-hooks": "2.0.0",
-    "istanbul": "1.1.0-alpha.1",
-    "mocha": "3.3.0",
-    "rimraf": "2.6.1",
-    "semistandard": "11.0.0",
-    "sift": "3.3.3"
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.24.1",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-es2015": "^6.24.1",
+    "chai": "^3.5.0",
+    "feathers": "^2.1.1",
+    "feathers-hooks": "^2.0.1",
+    "istanbul": "^1.1.0-alpha.1",
+    "mocha": "^3.3.0",
+    "rimraf": "^2.6.1",
+    "semistandard": "^11.0.0",
+    "sift": "^3.3.4"
   }
 }

--- a/src/checkUniqueness.js
+++ b/src/checkUniqueness.js
@@ -37,7 +37,7 @@ module.exports = function checkUniqueness (options, identifyUser, ownId, meta) {
           { errors: errs }
         );
       }
-    
+
       return null;
     });
 };


### PR DESCRIPTION
They were locked for some reason which shouldn't be necessary (this will also keep Greenkeeper from sending pull request for every new version).

- Closes https://github.com/feathersjs/feathers-authentication-management/pull/35
- Closes https://github.com/feathersjs/feathers-authentication-management/pull/36
- Closes https://github.com/feathersjs/feathers-authentication-management/pull/37