### PR TITLE
removed not required crypto package from dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "bcryptjs": "^2.3.0",
-    "crypto": "^0.0.3",
     "debug": "^2.6.4",
     "feathers-authentication-local": "^0.4.0",
     "feathers-errors": "^2.7.1",


### PR DESCRIPTION
I have removed crypto package from required packages.
It just creates a confusion because nodejs already has a crypto as in build package.We should try to avoid using non standard, not well tested cryptography packages. Using such packages might become security problem in the future.