### PR TITLE
Allow hook.addVerification on Patch and Update hooks

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -124,6 +124,12 @@ const ensureValuesAreStrings = (...rest) => {
   }
 };
 
+// Verify that obj1 and obj2 have different 'field' field
+// Returns false if either object is null/undefined
+const ensureFieldHasChanged = (obj1, obj2) => (field) => {
+  return obj1 && obj2 && obj1[field] !== obj2[field];
+};
+
 const sanitizeUserForClient = user => {
   const user1 = cloneObject(user);
 
@@ -193,6 +199,7 @@ module.exports = {
   getUserData,
   ensureObjPropsValid,
   ensureValuesAreStrings,
+  ensureFieldHasChanged,
   sanitizeUserForClient,
   sanitizeUserForNotifier,
   notifier

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -8,7 +8,6 @@ const { getLongToken, getShortToken, ensureFieldHasChanged } = require('./helper
 module.exports.addVerification = path => hook => {
   checkContext(hook, 'before', ['create', 'patch', 'update']);
 
-
   return Promise.resolve()
     .then(() => hook.app.service(path || 'authManagement').create({ action: 'options' }))
     .then(options => Promise.all([
@@ -17,13 +16,12 @@ module.exports.addVerification = path => hook => {
       getShortToken(options.shortTokenLen, options.shortTokenDigits)
     ]))
     .then(([options, longToken, shortToken]) => {
-
       // We do NOT add verification fields if the 3 following conditions are fulfilled:
       // - hook is PATCH or PUT
       // - user is authenticated
       // - user's identifyUserProps fields did not change
       if (
-        (hook.method === 'PATCH' || hook.method === 'PUT') &&
+        (hook.method === 'patch' || hook.method === 'update') &&
         !!hook.params.user &&
         !options.identifyUserProps.some(ensureFieldHasChanged(hook.data, hook.params.user))
       ) {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -6,7 +6,7 @@ const { checkContext } = require('feathers-hooks-common');
 const { getLongToken, getShortToken } = require('./helpers');
 
 module.exports.addVerification = path => hook => {
-  checkContext(hook, 'before', 'create');
+  checkContext(hook, 'before', ['create', 'patch', 'update']);
 
   return Promise.resolve()
     .then(() => hook.app.service(path || 'authManagement').create({ action: 'options' }))

--- a/test/addVerification.test.js
+++ b/test/addVerification.test.js
@@ -92,7 +92,7 @@ describe('hook:addVerification', () => {
         });
     });
   });
-  
+
   describe('long token', () => {
     it('length option works', (done) => {
       const options = { longTokenLen: 10 };
@@ -258,7 +258,107 @@ describe('hook:addVerification', () => {
         });
     });
   });
+
+  describe('patch & update', () => {
+
+    it('works with patch', (done) => {
+      const app = feathersStubs.app();
+      authManagementService().call(app); // define and attach authManagement service
   
+      hookIn = {
+        type: 'before',
+        method: 'patch',
+        data: { email: 'a@a.com', password: '0000000000' },
+        app,
+        params: {
+          user: { email: 'b@b.com' }
+        }
+      };
+      
+      hooks.addVerification()(hookIn)
+        .then(hook => {
+          const user = hook.data;
+  
+          assert.strictEqual(user.isVerified, false, 'isVerified not false');
+          assert.isString(user.verifyToken, 'verifyToken not String');
+          assert.equal(user.verifyToken.length, 30, 'verify token wrong length');
+          assert.equal(user.verifyShortToken.length, 6, 'verify short token wrong length');
+          assert.match(user.verifyShortToken, /^[0-9]+$/);
+          aboutEqualDateTime(user.verifyExpires, makeDateTime());
+          assert.deepEqual(user.verifyChanges, {}, 'verifyChanges not empty object');
+  
+          done();
+        })
+        .catch(() => {
+          assert.fail(true, false, 'unexpected error');
+          
+          done();
+        });
+    });
+
+    it('works with update', (done) => {
+      const app = feathersStubs.app();
+      authManagementService().call(app); // define and attach authManagement service
+  
+      hookIn = {
+        type: 'before',
+        method: 'update',
+        data: { email: 'a@a.com', password: '0000000000' },
+        app,
+        params: {
+          user: { email: 'b@b.com' }
+        }
+      };
+      
+      hooks.addVerification()(hookIn)
+        .then(hook => {
+          const user = hook.data;
+  
+          assert.strictEqual(user.isVerified, false, 'isVerified not false');
+          assert.isString(user.verifyToken, 'verifyToken not String');
+          assert.equal(user.verifyToken.length, 30, 'verify token wrong length');
+          assert.equal(user.verifyShortToken.length, 6, 'verify short token wrong length');
+          assert.match(user.verifyShortToken, /^[0-9]+$/);
+          aboutEqualDateTime(user.verifyExpires, makeDateTime());
+          assert.deepEqual(user.verifyChanges, {}, 'verifyChanges not empty object');
+  
+          done();
+        })
+        .catch(() => {
+          assert.fail(true, false, 'unexpected error');
+          
+          done();
+        });
+    });
+  
+    it('doesn\'t modify hook if email not updated', (done) => {
+      const app = feathersStubs.app();
+      authManagementService().call(app); // define and attach authManagement service
+  
+      hookIn = {
+        type: 'before',
+        method: 'update',
+        data: { email: 'a@a.com', password: '0000000000' },
+        app,
+        params: {
+          user: { email: 'a@a.com' }
+        }
+      };
+      
+      hooks.addVerification()(hookIn)
+        .then(hook => {
+          const user = hook.data;
+          assert.deepEqual(user, { email: 'a@a.com', password: '0000000000' }, 'hook.data modified');
+  
+          done();
+        })
+        .catch(() => {
+          assert.fail(true, false, 'unexpected error');
+          
+          done();
+        });
+    });
+  });
   
   it('throws if not before', () => {
     hookIn.type = 'after';
@@ -266,8 +366,8 @@ describe('hook:addVerification', () => {
     assert.throws(() => { hooks.isVerified()(hookIn); });
   });
   
-  it('throws if not create', () => {
-    hookIn.method = 'update';
+  it('throws if not create, update or patch', () => {
+    hookIn.method = 'get';
     
     assert.throws(() => { hooks.isVerified()(hookIn); });
   });


### PR DESCRIPTION
### Summary

- [ ] Tell us about the problem your pull request is solving.

In some apps, the `email` field is optional. We would then want to add the verification fields when this field is later on updated by the user (with `PATCH` or `PUT`).

This PR allows the `addVerification` hook as update and patch hooks.

- [ ] Are there any open issues that are related to this?

Yes, #59.

- [ ] Is this PR dependent on PRs in other repos?

No.

### Other Information

The hook does not fire if the user called `PATCH` or `PUT` without changing his email address. More specifically, it returns the incoming hook unaltered if the 3 conditions are met:

- hook is an update or patch hook
- user is authenticated
- user's old email and hook.data's email are the same