### PR TITLE
Make randomDigits use crypto.randomBytes

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -39,8 +39,13 @@ const randomBytes = len => new Promise((resolve, reject) => {
 });
 
 const randomDigits = len => {
-  const str = Math.random().toString() + Array(len + 1).join('0');
-  return str.substr(2, len);
+  let str = '';
+
+  while (str.length < len) {
+    str += parseInt('0x' + crypto.randomBytes(4).toString('hex')).toString();
+  }
+
+  return str.substr(0, len);
 };
 
 const getLongToken = len => randomBytes(len);


### PR DESCRIPTION
### Summary

Math.random() is a cryptographically insecure random number generator in V8. See https://stackoverflow.com/questions/5651789/is-math-random-cryptographically-secure or https://v8project.blogspot.com/2015/12/theres-mathrandom-and-then-theres.html for information on Math.random's security.

While randomBytes uses the CSPRNG `crypto.randomBytes`, `randomDigits` uses `Math.random`. This should not be used for generating any type of secret in an authentication workflow, especially when `randomBytes` is right there for use.

This generates a hexadecimal string using `crypto.randomBytes` in blocks and converts to decimal for use. `npm test` passes this PR using the existing test for `randomDigits`.
